### PR TITLE
Tailor the nginx-dev container for platformweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,43 @@
 ## Overview
 This repo is a nginx reverse proxy for the development environment. It allows
 you to hit the local dev URLs without needing to put in the port and to setup
-local HTTPS/SSL support. It's also a handy reference for the port numbers for each
-dev application.
+local HTTPS/SSL support.
 
-## SSL Support
+### Get the container running for https://platformweb access
+1. Get the code on your machine. Assuming you'll store your code in `~/src` run the following (you can use a different directory too):
+
+       cd ~/src
+       git clone https://github.com/bebraven/nginx-dev.git
+       cd nginx-dev
+
+2. Make your machine trust the self-signed SSL cert. On a Mac:
+    1. Open up Keychain Access app
+    2. Click on Certificates on the left
+    3. Drag the `platformweb-selfsigned.crt` from the root of this repo into there
+    4. Double click it
+    5. Expand the Trust section
+    6. Change the setting to *"When using this certificate" : "Always Trust"*
+    7. Close the dialog and type your computer password to save.
+
+3. Follow **Step 8** from the [Platform Initial Setup](https://github.com/bebraven/platform/wiki/Initial-Setup#get-the-app-running) to get `platformweb` into your `/etc/hosts` file
+
+4. Assuming you have Docker installed, fire up the container using: `docker-compose up -d` from the `nginx-dev` directory
+
+    *This will take awhile the first time*
+
+5. Does it work? Hit https://platformweb in your favorite browser and it should bring you to the login page.
+
+## Troubleshooting
+1. Make sure the container is running using `docker ps`. You should see the `nginx:latest` image running.
+
+2. Occasionally you'll get a `Bad Gateway nginx 1.17.4` error. Not sure why, but if you just restart the
+service using `./docker-compose/scripts/restart.sh` it should work.
+
+## Original setup instructions for platformweb SSL support
 Instead of adding support in each application and switching to boot it in SSL mode, the nginx reverse
 proxy allows an easy way to run the app in HTTP mode but to be able to hit it in SSL mode. We've done
 this for the [Braven Platform](https://github.com/bebraven/platform) app which runs locally
-at http://platformweb:3020
-
-### platformweb
-To access https://platformweb on a Mac, simply:
-1. Open up Keychain Access app
-2. Click on Certificates on the left
-3. Drag the `platformweb-selfsigned.crt` from the root of this repo into there
-4. Double click it
-5. Expand the Trust section
-6. Change the setting to *"When using this certificate" : "Always Trust"*
-7. Close the dialog and type your computer password to save.
-
-After doing this, if you restart this container and hit https://platformweb (assuming you have an entry in `/etc/hosts` for platformweb), it should work with no warnings about the site being unsafe.
-
-#### Original setup instructions for platformweb SSL support
+at http://platformweb:3020 but you can hit it at https://platformweb with this container running.
 
 In case you need to setup SSL support for another app in the future, here is how it
 was setup for `platformweb`
@@ -55,9 +70,3 @@ openssl req \
 4. We did the Mac Keychain Access step above to let our local computers trust the self-signed .crt
 
 5. Finally, we edited the `nginx.conf` to liston on port 443 and use the new self-signed key which you've told your local computer to trust. Just look at the platformweb config in there for an example
-
-## Troubleshooting
-Occasionally you'll get a `Bad Gateway nginx 1.17.4` error. Not sure why, but if you just restart the
-service using `./docker-compose/scripts/restart.sh` it should work.
-
-

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,66 +9,6 @@ http {
   proxy_read_timeout 600;
 
   server {
-    server_name canvasweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://canvasweb:3000;
-      rewrite ^/canvasweb(.*)$ $1 break;
-    }
-  }
-
-  server {
-    server_name cssjsweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://cssjsweb:3004;
-      rewrite ^/cssjsweb(.*)$ $1 break;
-    }
-  }
-
-  server {
-    server_name joinweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://joinweb:3001;
-      rewrite ^/joinweb(.*)$ $1 break;
-    }
-  }
-
-  server {
-    server_name ssoweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://ssoweb:3002;
-      rewrite ^/ssoweb(.*)$ $1 break;
-    }
-  }
-
-  server {
-    server_name kitsweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://kitsweb:3005;
-      rewrite ^/kitsweb(.*)$ $1 break;
-    }
-  }
-
-  server {
-    server_name bravenweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://bravenweb:3007;
-      rewrite ^/bravenweb(.*)$ $1 break;
-    }
-  }
-
-  server {
     server_name platformweb;
     listen 80;
     listen 443 ssl http2;
@@ -79,18 +19,6 @@ http {
       proxy_pass http://platformweb:3020;
       rewrite ^/platformweb(.*)$ $1 break;
       proxy_set_header  Host platformweb;
-      proxy_set_header  X-Forwarded-Proto $scheme;
-    }
-  }
-
-  server {
-    server_name boosterplatformweb;
-    listen 80;
-
-    location / {
-      proxy_pass http://boosterplatformweb:3020;
-      rewrite ^/boosterplatformweb(.*)$ $1 break;
-      proxy_set_header  Host boosterplatformweb;
       proxy_set_header  X-Forwarded-Proto $scheme;
     }
   }


### PR DESCRIPTION
All the old local apps can still be supported if you use this repo:
https://github.com/beyond-z/nginx-dev

But the one at: https://github.com/bebraven/nginx-dev now only supports
`platformweb` and won't fail to start if you don't have all the legacy
domains in `/etc/hosts`

Cleaned up the docs at https://github.com/bebraven/platform/wiki/Initial-Setup#get-the-app-running to match this